### PR TITLE
Adding timestamps to surveys #60

### DIFF
--- a/server/src/models/surveys/SurveyCommon.js
+++ b/server/src/models/surveys/SurveyCommon.js
@@ -5,6 +5,11 @@ import { commonQuestions, submissionStatusArray, schoolsArray } from '../../sche
 // Generate a mongoose-compatible version of the question schema
 const mappedCommonQuestions = questionSchemaToMongooseModel(commonQuestions);
 
+const currentESTDateTime = {
+    // add the timestamp, set as the server side EST current time
+    timestamps: { currentTime: () => new Date().toLocaleString("en-US", {timeZone: "America/New_York"})}
+  };
+
 const surveyCommonSchema = new mongoose.Schema({
     status: {
         type: String,
@@ -22,7 +27,7 @@ const surveyCommonSchema = new mongoose.Schema({
         default: false,
     },
     ...mappedCommonQuestions,
-});
+}, currentESTDateTime);
 
 const SurveyCommon = mongoose.model('SurveyCommon', surveyCommonSchema);
 


### PR DESCRIPTION
As suggested, using mongoose instead of the controller, ref: https://masteringjs.io/tutorials/mongoose/timestamps,

Tested locally and the properties where added when a new survey was creadted:
  "createdAt": "2020-11-13T23:22:18.000Z",
  "updatedAt": "2020-11-13T23:22:18.000Z",